### PR TITLE
feat: use ibi pelias transit fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Some users would like their OTP instance location autocomplete responses to include custom POIs as well as bus stops. This information is supplied in custom CSV files ([in a format Pelias understands](https://github.com/pelias/csv-importer)) and GTFS stops.txt files.
 
-The `server-install` directory includes scripts and configuration files to launch the custom [Pelias](https://github.com/pelias/docker) instance which serves the custom responses. More details about the script [are available in the `server-install` directory](https://github.com/ibi-group/transit-pois-pelias/tree/master/server-install).
+The `server-install` directory includes scripts and configuration files to launch the custom [Pelias](https://github.com/pelias/docker) instance which serves the custom responses. More details about the scripts [are available in the `server-install` directory](https://github.com/ibi-group/transit-pois-pelias/tree/master/server-install).
 
 The `pelias-config` directory contains configuration files for the Pelias instance `server-install` installs. It also includes [instructions for running this server locally](https://github.com/ibi-group/transit-pois-pelias/tree/master/pelias-config).
 

--- a/pelias-config/docker-compose.yml
+++ b/pelias-config/docker-compose.yml
@@ -39,7 +39,7 @@ services:
             - ${DATA_DIR}:/data
             - ./blacklist/:/data/blacklist
     transit:
-        image: pelias/transit:master
+        image: milesgrantibigroup/ibi-transit:v5
         container_name: pelias_transit
         user: ${DOCKER_USER}
         volumes:

--- a/server-install/README.md
+++ b/server-install/README.md
@@ -2,6 +2,8 @@
 
 The scripts here are for installing a Pelias server for transit and csv use only on an Amazon EC2 (although other Ubuntu Server instances should also work). For installing locally, please refer to the instructions in the `pelias-config` folder.
 
+`server-install.sh` installs the dependencies needed to run `install-pelias.sh`. The scripts are split to allow Docker group changes to register in the shell.
+
 This script was tested with Ubuntu 20.04 on an Amazon EC2 r5a.large. However, it should work with any Ubuntu/Debian-based server with minimal changes.
 
 The script assumes this repository has been copied to the home directory of the default ubuntu user (as a folder `transit-pois-pelias`). Running the `pelias-start.sh` script will then install all needed dependencies, set them up and launch the Pelias instance and a webhook for adding content to the instance.

--- a/server-install/install-pelias.sh
+++ b/server-install/install-pelias.sh
@@ -1,0 +1,48 @@
+# Install Pelias
+git clone https://github.com/pelias/docker.git && mv docker pelias-docker && cd pelias-docker
+sudo ln -s "$(pwd)/pelias" /usr/local/bin/pelias
+
+cd ~/transit-pois-pelias/pelias-config/
+
+# Initialize containers
+pelias compose pull
+pelias elastic start
+pelias elastic wait
+pelias elastic create
+
+# Initial import
+pelias import csv
+pelias import transit
+
+# Run Pelias
+pelias compose up
+
+# Setup NGINX
+sudo apt install nginx -y
+
+# Install webhook dependencies
+cd ~/transit-pois-pelias/webhook/
+yarn install
+
+# Be in script directory for copying
+cd ~/transit-pois-pelias/server-install/
+
+# Copy default config
+sudo /bin/cp nginx-config /etc/nginx/sites-enabled/default
+
+# Restart nginx
+sudo systemctl restart nginx
+
+# Copy systemd files for Pelias, Webhook
+sudo /bin/cp pelias.service /lib/systemd/system/
+sudo /bin/cp pelias-webhook.service /lib/systemd/system
+
+# Enable the new services
+sudo systemctl daemon-reload
+sudo systemctl enable pelias
+
+sudo systemctl unmask pelias-webhook
+sudo systemctl enable pelias-webhook
+
+# Pelias is already running
+sudo systemctl start pelias-webhook

--- a/server-install/server-install.sh
+++ b/server-install/server-install.sh
@@ -32,6 +32,8 @@ sudo snap install docker
 sudo apt install util-linux -y
 
 # Correct Docker permissions
+sudo groupadd docker
+sudo usermod -aG docker $USER
 sudo snap connect docker:home
 sudo chgrp docker $(which docker)
 sudo chmod g+s $(which docker)
@@ -45,52 +47,3 @@ sudo snap start docker
 sleep 5
 # This is needed to get snap Docker to initialize fully
 docker run hello-world
-
-# Install Pelias
-git clone https://github.com/pelias/docker.git && mv docker pelias-docker && cd pelias-docker
-sudo ln -s "$(pwd)/pelias" /usr/local/bin/pelias
-
-cd ~/transit-pois-pelias/pelias-config/
-
-# Initialize containers
-pelias compose pull
-pelias elastic start
-pelias elastic wait
-pelias elastic create
-
-# Initial import
-pelias import csv
-pelias import transit
-
-# Run Pelias
-pelias compose up
-
-# Setup NGINX
-sudo apt install nginx -y
-
-# Install webhook dependencies
-cd ~/transit-pois-pelias/webhook/
-yarn install
-
-# Be in script directory for copying
-cd ~/transit-pois-pelias/server-install/
-
-# Copy default config
-sudo /bin/cp nginx-config /etc/nginx/sites-enabled/default
-
-# Restart nginx
-sudo systemctl restart nginx
-
-# Copy systemd files for Pelias, Webhook
-sudo /bin/cp pelias.service /lib/systemd/system/
-sudo /bin/cp pelias-webhook.service /lib/systemd/system
-
-# Enable the new services
-sudo systemctl daemon-reload
-sudo systemctl enable pelias
-
-sudo systemctl unmask pelias-webhook
-sudo systemctl enable pelias-webhook
-
-# Pelias is already running
-sudo systemctl start pelias-webhook


### PR DESCRIPTION
This PR uses a fork of the Pelias transit image, and breaks up the server install script to make the installation process more bug-free.