### PR TITLE
Support Dropping Pelias DB

### DIFF
--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -179,9 +179,18 @@ const status: Status = {
   })
   const last50Logs: CircularBuffer = new CircularBuffer(50)
 
+  // Create an extra set of commands to drop the db should the config specify to
+  let resetCommands = ''
+  if (config.resetDb) {
+    resetCommands = 'pelias elastic drop -f && pelias elastic create &&'
+  }
+
   const subprocess: ExecaChildProcess = execa(
     'sh',
-    ['-c', `pelias download csv && pelias import csv && pelias import transit`],
+    [
+      '-c',
+      `${resetCommands} pelias download csv && pelias import csv && pelias import transit`
+    ],
     { all: true, cwd: PELIAS_CONFIG_DIR }
   )
 

--- a/webhook/utils.ts
+++ b/webhook/utils.ts
@@ -14,6 +14,7 @@ export type WebhookConfig = {
   deploymentId: string
   gtfsFeeds: Array<{ filename: string; name: string; uri: string }>
   logUploadUrl: string
+  resetDb: boolean
   workerId: string
 }
 export type WebhookFeed = {


### PR DESCRIPTION
Adds a new field for requesting the Pelias DB be dropped and adds needed commands should the field be set to true.