### PR TITLE
Correctly Upload Logs to S3

### DIFF
--- a/webhook/utils.ts
+++ b/webhook/utils.ts
@@ -125,7 +125,7 @@ export const writeStatus = async (
   // merge statuses together
   const newStatus = { ...currentStatus, ...updatedStatus }
   // write updated status to status file
-  console.log('TEMP:', newStatus)
+  console.log('Writing Status:', newStatus)
   await writeJSON(statusFile, newStatus)
 }
 


### PR DESCRIPTION
The webhook has been uploading files to s3 incorrectly, saving them to files with the name of the log upload folders instead of uploading the file correctly. This PR fixes this, uploading the file correctly.