### PR TITLE
Ease-of-Use Patches

### DIFF
--- a/server-install/README.md
+++ b/server-install/README.md
@@ -12,15 +12,17 @@ The server will run on port 80 (via nginx). Please note that by default there is
 
 
 ### Firewall Configuration with AWS and `pelias-stitch`
-A good Security Group configuration for the ec2 instance this server runs on will only allow traffic from a datatools instance and from the `pelias-stitch` Lambda function. Unfortunately, Lambda functions don't have a consistent IP address they produce requests from, so using a firewall becomes difficult. AWS allows a firewall to allow Lambda from a security group, but requires the security group to be in the same VPC as the ec2. A Lambda function inside a VPC can not access the outside internet without a NAT Gateway.
+A good Security Group configuration for the EC2 instance this server runs on will only allow traffic from a datatools instance and from the `pelias-stitch` Lambda function. Unfortunately, Lambda functions don't have a consistent IP address they produce requests from, so using a firewall becomes difficult. AWS allows a firewall to allow Lambda from a security group, but requires the security group to be in the same VPC as the EC2. A Lambda function inside a VPC can not access the outside internet without a NAT Gateway.
 
 #### The Solution
 Adding a NAT Gateway to an existing VPC requires two subnets within the VPC. The first subnet should be a _public_ subnet. This subnet will contain only the NAT Gateway. The second subnet should be a _private_ subnet. This subnet will contain the Lambda functions and the EC2 instances. 
 
-The public subnet needs to have an *Internet Gateway* attached to it (this is different from a NAT Gateway). The public subnet routing table then needs to be updated to route `0.0.0.0/0` to the Internet Gateway. 
+The public subnet needs to have an **Internet Gateway** attached to it (this is different from a NAT Gateway). The public subnet routing table then needs to be updated to route `0.0.0.0/0` to the Internet Gateway. 
 
-The private subnet needs to have a *NAT Gateway* attached to it. The private subnet routing table then needs to be updated to route `0.0.0.0/0` to the NAT Gateway. 
+The private subnet needs to have a **NAT Gateway** attached to it. The private subnet routing table then needs to be updated to route `0.0.0.0/0` to the NAT Gateway. 
 
 The `pelias-stitcher` can then be configured to make requests both to IPs within its VPC and IPs in the open web (which will be routed according to the Private subnet's routing table).
+
+##### Running `pelias-stitch` in its own VPC
 
 Those not comfortable with adding a NAT Gateway to the VPC their EC2 instances are in can place the Lambda functions in their own VPC, and use the elastic IP of the Internet Gateway as an allowed IP for their firewall rules. Be sure to note that the `pelias-stitcher` will now need to communicate with the EC2 instance via the open web.

--- a/server-install/README.md
+++ b/server-install/README.md
@@ -9,3 +9,18 @@ This script was tested with Ubuntu 20.04 on an Amazon EC2 r5a.large. However, it
 The script assumes this repository has been copied to the home directory of the default ubuntu user (as a folder `transit-pois-pelias`). Running the `pelias-start.sh` script will then install all needed dependencies, set them up and launch the Pelias instance and a webhook for adding content to the instance.
 
 The server will run on port 80 (via nginx). Please note that by default there is no protection of the server. This should be done via firewall rules.
+
+
+### Firewall Configuration with AWS and `pelias-stitch`
+A good Security Group configuration for the ec2 instance this server runs on will only allow traffic from a datatools instance and from the `pelias-stitch` Lambda function. Unfortunately, Lambda functions don't have a consistent IP address they produce requests from, so using a firewall becomes difficult. AWS allows a firewall to allow Lambda from a security group, but requires the security group to be in the same VPC as the ec2. A Lambda function inside a VPC can not access the outside internet without a NAT Gateway.
+
+#### The Solution
+Adding a NAT Gateway to an existing VPC requires two subnets within the VPC. The first subnet should be a _public_ subnet. This subnet will contain only the NAT Gateway. The second subnet should be a _private_ subnet. This subnet will contain the Lambda functions and the EC2 instances. 
+
+The public subnet needs to have an *Internet Gateway* attached to it (this is different from a NAT Gateway). The public subnet routing table then needs to be updated to route `0.0.0.0/0` to the Internet Gateway. 
+
+The private subnet needs to have a *NAT Gateway* attached to it. The private subnet routing table then needs to be updated to route `0.0.0.0/0` to the NAT Gateway. 
+
+The `pelias-stitcher` can then be configured to make requests both to IPs within its VPC and IPs in the open web (which will be routed according to the Private subnet's routing table).
+
+Those not comfortable with adding a NAT Gateway to the VPC their EC2 instances are in can place the Lambda functions in their own VPC, and use the elastic IP of the Internet Gateway as an allowed IP for their firewall rules. Be sure to note that the `pelias-stitcher` will now need to communicate with the EC2 instance via the open web.

--- a/server-install/install-pelias.sh
+++ b/server-install/install-pelias.sh
@@ -22,7 +22,7 @@ sudo apt install nginx -y
 
 # Install webhook dependencies
 cd ~/transit-pois-pelias/webhook/
-yarn install
+yarn install --no-cache --cache-folder /tmp/
 yarn build
 
 # Be in script directory for copying

--- a/server-install/pelias.service
+++ b/server-install/pelias.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Pelias
-After=docker.service
-BindsTo=docker.service
-ReloadPropagatedFrom=docker.service
+After=pelias-webhook.service
 
 [Service]
 Type=oneshot

--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -113,23 +113,6 @@ const status: Status = {
     message: 'Importing CSV',
     percentComplete: 40.0
   })
-  // We want to replace all csv files associated with the deployment
-  // to remove outdated POIs
-  const existingCsvNotInCurrentProject: string[] =
-    peliasConfig.imports.csv.download.filter((csvUrl: string) => {
-      let deploymentIdFromCsvName = ''
-      // CSV urls not guaranteed to conform to the way theya are generated in
-      // https://github.com/ibi-group/datatools-server/blob/dev/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
-
-      // Only process if length is correct
-      if (csvUrl.split('/').length === 8) {
-        deploymentIdFromCsvName = csvUrl.split('/')[6]
-      }
-      // Only keep CSV files which don't originate from this project
-      // We don't garuntee deploymentId is supplied, but if it is not, this will always
-      // be true
-      return config.deploymentId !== deploymentIdFromCsvName
-    })
 
   // Append CSV urls to pelias imports, merging
   // the existing and new csv URL lists
@@ -139,9 +122,7 @@ const status: Status = {
   poiCsvUrls = poiCsvUrls.map(encodeURI)
 
   // Assemble all urls into new pelias config property
-  peliasConfig.imports.csv.download = Array.from(
-    new Set([...existingCsvNotInCurrentProject, ...poiCsvUrls])
-  )
+  peliasConfig.imports.csv.download = poiCsvUrls
 
   // Write new pelias config based on generated blocks
   try {

--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -180,16 +180,20 @@ const status: Status = {
   const last50Logs: CircularBuffer = new CircularBuffer(50)
 
   // Create an extra set of commands to drop the db should the config specify to
-  let resetCommands = ''
+  let resetCommandsPre = ''
+  let resetCommandsPost = 'echo "Import Complete"'
+
   if (config.resetDb) {
-    resetCommands = 'pelias elastic drop -f && pelias elastic create &&'
+    resetCommandsPre = 'pelias elastic drop -f && pelias elastic create &&'
+    resetCommandsPost =
+      'pelias compose down && ~/transit-pois-pelias/server-install/pelias-start.sh'
   }
 
   const subprocess: ExecaChildProcess = execa(
     'sh',
     [
       '-c',
-      `${resetCommands} pelias download csv && pelias import csv && pelias import transit`
+      `${resetCommandsPre} pelias download csv && pelias import csv && pelias import transit && ${resetCommandsPost}`
     ],
     { all: true, cwd: PELIAS_CONFIG_DIR }
   )


### PR DESCRIPTION
This PR contains various patches to both the setup scripts and the automated update scripts that ensure that a Pelias instance can exist and be updated with less manual intervention. Most crucially, a reset request will now entirely restart Pelias which helps solve a number of common issues and used to require manual intervention. 

This PR includes a breaking change that removes the functionality that preserves csv files not included in a new deployment. This feature was added when the way the webhook would be used was not yet understood.