### PR TITLE
fix(processConfig): increase pelias timeout

### DIFF
--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -222,7 +222,7 @@ const status: Status = {
   // either report success or failure based on exit code
   if (subprocess.exitCode > 0) {
     await fail(
-      `Pelias failed to update. Pelias commands exited with non-zero exit code. Check log file for workerID ${config.workerId}`
+      `Pelias failed to update. Pelias commands exited with non-zero exit code. Check log file for workerID ${config.workerId} uploaded to ${config.logUploadUrl}`
     )
   }
 

--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -184,7 +184,7 @@ const status: Status = {
   // Set a timeout to avoid hanging
   const hangCheck: AbortController = new AbortController()
   const signal: AbortSignal = hangCheck.signal
-  setPromisedTimeout(50000, null, { signal })
+  setPromisedTimeout(160000, null, { signal })
     .then(async () => await fail('Pelias update is hanging'))
     .catch((err) => {
       if (err.name === 'AbortError') console.log('Pelias did not hang')

--- a/webhook/utils.ts
+++ b/webhook/utils.ts
@@ -161,6 +161,7 @@ export const uploadAndDeleteLog = async ({
         logPath,
         `${logUploadUrl}/pelias-update-log-${workerId}.txt`
       ])
+      console.log(`Uploaded log to ${logUploadUrl}`)
     } catch {
       console.warn('Failed to upload log, not deleting it.')
       return


### PR DESCRIPTION
With Pelias getting more complex, the timeout can often terminate an update before it has time to finish. 

This PR also makes small changes to make log files for failures easier to find.