### PR TITLE
Add Pelias-Restart Cronjob

### DIFF
--- a/server-install/install-pelias.sh
+++ b/server-install/install-pelias.sh
@@ -38,6 +38,9 @@ sudo systemctl restart nginx
 sudo /bin/cp pelias.service /lib/systemd/system/
 sudo /bin/cp pelias-webhook.service /lib/systemd/system
 
+# Copy crontab for weekly auto-restart
+sudo /bin/cp reset-pelias.sh /etc/cron.weekly/
+
 # Enable the new services
 sudo systemctl daemon-reload
 sudo systemctl enable pelias

--- a/server-install/reset-pelias.sh
+++ b/server-install/reset-pelias.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+# Reset Pelias
+# Assumes Pelias is installed and running
+cd ~/transit-pois-pelias/pelias-config && pelias elastic drop -f && pelias elastic create && pelias download csv && pelias import csv && pelias import transit && pelias compose down && ~/transit-pois-pelias/server-install/pelias-start.sh


### PR DESCRIPTION
Elasticsearch was crashing sometimes. This PR attempts to resolve this by introducing a new cron job that resets Pelias every week.