### PR TITLE
Remove station/stop separation

### DIFF
--- a/pelias-config/docker-compose.yml
+++ b/pelias-config/docker-compose.yml
@@ -39,7 +39,7 @@ services:
             - ${DATA_DIR}:/data
             - ./blacklist/:/data/blacklist
     transit:
-        image: milesgrantibigroup/ibi-transit:v5
+        image: pelias/transit:master
         container_name: pelias_transit
         user: ${DOCKER_USER}
         volumes:


### PR DESCRIPTION
The custom docker image we were using to replace Pelias' wasn't quite accurate. This PR removes this custom image. The splitting can always be added again later.