### PR TITLE
Support Pelias Synonyms File

### DIFF
--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -93,7 +93,9 @@ const status: Status = {
       { encoding: 'base64' },
       function (err) {
         console.log('File created')
-        console.log(err)
+        if (err) {
+          console.log(err)
+        }
       }
     )
   }

--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 import { setTimeout as setPromisedTimeout } from 'timers/promises'
+import { writeFile } from 'fs'
 
 import { createFile as touch, readJSON, remove, writeJSON } from 'fs-promise'
 import execa, { ExecaChildProcess, ExecaSyncReturnValue } from 'execa'
@@ -83,6 +84,19 @@ const status: Status = {
       transit: { feeds: PeliasFeed[] }
     }
   } = require(`../${PELIAS_CONFIG_FILE}`)
+
+  if (config.peliasSynonymsBase64) {
+    await updateStatus({ message: 'Importing synonyms', percentComplete: 10.0 })
+    writeFile(
+      '../pelias-config/synonyms/custom_name.txt',
+      config.peliasSynonymsBase64.replace('data:text/plain;base64,', ''),
+      { encoding: 'base64' },
+      function (err) {
+        console.log('File created')
+        console.log(err)
+      }
+    )
+  }
 
   await updateStatus({
     message: 'Downloading GTFS feeds',

--- a/webhook/utils.ts
+++ b/webhook/utils.ts
@@ -14,6 +14,7 @@ export type WebhookConfig = {
   deploymentId: string
   gtfsFeeds: Array<{ filename: string; name: string; uri: string }>
   logUploadUrl: string
+  peliasSynonymsBase64?: string
   resetDb: boolean
   workerId: string
 }


### PR DESCRIPTION
Along with https://github.com/ibi-group/datatools-server/pull/547 and https://github.com/ibi-group/datatools-ui/pull/963, this PR adds support for a new part of the webhook request, a Pelias `custom_name.txt` file. This file is then inserted into the pelias config directory.

This seems to work in most cases, although I'm still testing a few potential environments that cause problems