### PR TITLE
Remove support for preserving feeds during an update

### DIFF
--- a/webhook/processConfig.ts
+++ b/webhook/processConfig.ts
@@ -116,14 +116,7 @@ const status: Status = {
     await fail('No new Pelias feeds were provided for import')
   }
   // Merge into existing pelias config
-  peliasConfig.imports.transit.feeds = [
-    // Include all existing feeds that don't have the ID of the new feed
-    ...peliasConfig.imports.transit.feeds.filter(
-      (feed: PeliasFeed) =>
-        !newPeliasFeeds.map((f) => f.agencyId).includes(feed.agencyId)
-    ),
-    ...newPeliasFeeds
-  ]
+  peliasConfig.imports.transit.feeds = [...newPeliasFeeds]
 
   await updateStatus({
     message: 'Importing CSV',


### PR DESCRIPTION
It was decided that this behavior is not wanted. I can't remember why this behavior was implemented in the first place. Now, if a feed is not present in a webook request, it will be deleted!